### PR TITLE
Fix logic for mixing vtk and vtp files

### DIFF
--- a/tkompare
+++ b/tkompare
@@ -10,9 +10,9 @@ def compare(a, b):
   '''
   '''
 
-  if (os.path.splitext(a)[1].lower() == '.vtp' and \
-      os.path.splitext(b)[1].lower() == '.vtp') or \
-     (os.path.splitext(a)[1].lower() == '.vtk' and \
+  if (os.path.splitext(a)[1].lower() == '.vtp' or \
+      os.path.splitext(b)[1].lower() == '.vtp') and \
+     (os.path.splitext(a)[1].lower() == '.vtk' or \
       os.path.splitext(b)[1].lower() == '.vtk'):
 
     sizeA = os.path.getsize(a)


### PR DESCRIPTION
Previously the logic meant that both inputs needed
to be either both vtk or both vtp, even though the rest
of the program supports a mix.

Now the logic checks that both of the files are
either vtk or vtp.