### PR TITLE
Set active arrays in vtk polydata

### DIFF
--- a/trako/gltfi2vtk.py
+++ b/trako/gltfi2vtk.py
@@ -87,6 +87,7 @@ def convert(input, output=None, verbose=True):
   points = vtk.vtkPoints()
   points.SetData(numpy_support.numpy_to_vtk(draco_points_reshaped))
   polydata.SetPoints(points)
+  pointdata = polydata.GetPointData()
 
   #
   # scalars
@@ -101,11 +102,16 @@ def convert(input, output=None, verbose=True):
       scalarname = k[1:]
       vtkArr = numpy_support.numpy_to_vtk(draco_points_reshaped)
       vtkArr.SetName(scalarname)
-      polydata.GetPointData().AddArray(vtkArr)
+      pointdata.AddArray(vtkArr)
 
       if verbose:
         print('Restored scalar', scalarname)
 
+      if draco_points_reshaped.shape[1] == 1 and pointdata.GetScalars() is None:
+        pointdata.SetScalars(vtkArr)
+
+      if draco_points_reshaped.shape[1] == 9 and pointdata.GetTensors() is None:
+        pointdata.SetTensors(vtkArr)
   #
   #
   # now the indices / cell data

--- a/trako/util.py
+++ b/trako/util.py
@@ -1,5 +1,5 @@
 import numpy as np
-import matplotlib.pyplot as plt
+#import matplotlib.pyplot as plt
 import vtk
 from vtk.util import numpy_support
 


### PR DESCRIPTION
Previously untrakofy output a vtkPolyData with arrays
for each of the restored attributes, but it did not
set any of them active.  Some SlicerDMRI utilities require
a default active tensor be defined (even though it's not
semantically meaningful).

This change sets the first scalar array and the first
tensor array to be active in order to be compatible
with the expectations of the FiberTractMeasurements
tool in SlicerDMRI.

Fixes #11